### PR TITLE
Add default constructor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt update && sudo apt install -y libssh2-1-dev libssl-dev
+        run: sudo apt update && sudo apt install -y libssh2-1-dev libssl-dev && mkdir -p $HOME/.ssh && touch $HOME/.ssh/config
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt update && sudo apt install -y libssh2-1-dev libssl-dev
+        run: sudo apt update && sudo apt install -y libssh2-1-dev libssl-dev && mkdir -p $HOME/.ssh && touch $HOME/.ssh/config
       - name: Setup nightly toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ impl SshConfig {
         parser::SshConfigParser::parse(&mut self, reader, rules).map(|_| self)
     }
 
+    #[cfg(target_family = "unix")]
     /// Parse ~/.ssh/config file and return parsed configuration or parser error
     pub fn parse_default_file(rules: ParseRule) -> SshParserResult<Self> {
         let ssh_folder = dirs::home_dir()
@@ -149,6 +150,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(target_family = "unix")]
     fn should_parse_default_config() {
         assert!(SshConfig::parse_default_file(ParseRule::ALLOW_UNKNOWN_FIELDS).is_ok());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 #![doc(html_playground_url = "https://play.rust-lang.org")]
 
 use std::fs::File;
-use std::io::{BufRead, self, BufReader};
+use std::io::{self, BufRead, BufReader};
 use std::path::PathBuf;
 use std::time::Duration;
 // -- modules
@@ -114,15 +114,19 @@ impl SshConfig {
     /// Parse ~/.ssh/config file and return parsed configuration or parser error
     pub fn parse_default_file(rules: ParseRule) -> SshParserResult<Self> {
         let ssh_folder = dirs::home_dir()
-            .ok_or_else(|| SshParserError::Io(io::Error::new(io::ErrorKind::NotFound, "Home folder not found")))?
+            .ok_or_else(|| {
+                SshParserError::Io(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "Home folder not found",
+                ))
+            })?
             .join(".ssh");
 
-        let mut reader = BufReader::new(File::open(ssh_folder.join("config"))
-            .map_err(SshParserError::Io)?);
+        let mut reader =
+            BufReader::new(File::open(ssh_folder.join("config")).map_err(SshParserError::Io)?);
 
         Self::default().parse(&mut reader, rules)
     }
-
 
     pub fn get_hosts(&self) -> &Vec<Host> {
         &self.hosts
@@ -142,6 +146,27 @@ mod test {
         assert_eq!(config.hosts.len(), 1);
         assert_eq!(config.default_params(), HostParams::default());
         assert_eq!(config.query("192.168.1.2"), HostParams::default());
+    }
+
+    #[test]
+    fn should_parse_default_config() {
+        assert!(SshConfig::parse_default_file(ParseRule::ALLOW_UNKNOWN_FIELDS).is_ok());
+    }
+
+    #[test]
+    fn should_parse_config() {
+        use std::fs::File;
+        use std::io::BufReader;
+        use std::path::Path;
+
+        let mut reader = BufReader::new(
+            File::open(Path::new("./assets/ssh.config"))
+                .expect("Could not open configuration file"),
+        );
+
+        assert!(SshConfig::default()
+            .parse(&mut reader, ParseRule::STRICT)
+            .is_ok());
     }
 
     #[test]


### PR DESCRIPTION
# Add default constructor

## Description

Added a default constructor so that people only need to call `ssh2_config::SshConfig::parse_default_file`

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] The changes I've made are Windows, MacOS, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
