### PR TITLE
fix: correctly apply configuration precedence in reverse parsing order

### DIFF
--- a/assets/ssh.config
+++ b/assets/ssh.config
@@ -1,14 +1,11 @@
 # ssh config example
 
+# Command line options, overriding host-specific options
 Compression           yes
 ConnectionAttempts    10
 ConnectTimeout        60
 ServerAliveInterval   40
 TcpKeepAlive          yes
-
-Ciphers         aes128-ctr,aes192-ctr,aes256-ctr
-KexAlgorithms   diffie-hellman-group-exchange-sha256
-MACs            hmac-sha2-512,hmac-sha2-256,hmac-ripemd160
 
 # Host configuration
 
@@ -30,3 +27,8 @@ Host tostapane
 Host    192.168.1.30
     User            nutellaro
     RemoteForward   123
+
+Host *
+    Ciphers         aes128-ctr,aes192-ctr,aes256-ctr
+    KexAlgorithms   diffie-hellman-group-exchange-sha256
+    MACs            hmac-sha2-512,hmac-sha2-256,hmac-ripemd160

--- a/src/host.rs
+++ b/src/host.rs
@@ -2,8 +2,6 @@
 //!
 //! Ssh host type
 
-use std::cmp::Ordering;
-
 use wildmatch::WildMatch;
 
 use super::HostParams;
@@ -36,28 +34,6 @@ impl Host {
     }
 }
 
-impl std::cmp::PartialOrd for Host {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        let self_max_pattern = self.pattern.iter().max_by(|x, y| x.cmp(y));
-        let other_max_pattern = other.pattern.iter().max_by(|x, y| x.cmp(y));
-        match (self_max_pattern, other_max_pattern) {
-            (Some(_self), Some(other)) => Some(_self.cmp(other)),
-            _ => None,
-        }
-    }
-}
-
-impl std::cmp::Ord for Host {
-    fn cmp(&self, other: &Self) -> Ordering {
-        let self_max_pattern = self.pattern.iter().max_by(|x, y| x.cmp(y));
-        let other_max_pattern = other.pattern.iter().max_by(|x, y| x.cmp(y));
-        match (self_max_pattern, other_max_pattern) {
-            (Some(_self), Some(other)) => _self.cmp(other),
-            _ => Ordering::Equal,
-        }
-    }
-}
-
 /// Describes a single clause to match host
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HostClause {
@@ -74,18 +50,6 @@ impl HostClause {
     /// Returns whether `host` argument intersects the clause
     pub fn intersects(&self, host: &str) -> bool {
         WildMatch::new(self.pattern.as_str()).matches(host)
-    }
-}
-
-impl std::cmp::PartialOrd for HostClause {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.pattern.cmp(&other.pattern))
-    }
-}
-
-impl std::cmp::Ord for HostClause {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.pattern.cmp(&other.pattern)
     }
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -60,8 +60,19 @@ impl SshConfigParser {
         reader: &mut impl BufRead,
         rules: ParseRule,
     ) -> SshParserResult<()> {
+        // Options preceding the first `Host` section
+        // are parsed as command line options;
+        // overriding all following host-specific options.
+        //
+        // See https://github.com/openssh/openssh-portable/blob/master/readconf.c#L1051-L1054
+        config.hosts.push(Host::new(
+            vec![HostClause::new(String::from("*"), false)],
+            HostParams::default(),
+        ));
+
         // Current host pointer
         let mut current_host = config.hosts.last_mut().unwrap();
+
         let mut lines = reader.lines();
         // iter lines
         loop {
@@ -90,21 +101,21 @@ impl SshConfigParser {
             };
             // If field is block, init a new block
             if field == Field::Host {
-                // Get default params
-                let params = config.default_params();
-                // Parse arguments
-                let clause = Self::parse_host(args)?;
-                // Save
-                config.hosts.push(Host::new(clause, params));
-                // Update host
+                // Pass `ignore_unknown` from global overrides down into the tokenizer.
+                let mut params = HostParams::default();
+                params.ignore_unknown = config.hosts[0].params.ignore_unknown.clone();
+
+                // Add a new host
+                config
+                    .hosts
+                    .push(Host::new(Self::parse_host(args)?, params));
+                // Update current host pointer
                 current_host = config.hosts.last_mut().unwrap();
             } else {
                 // Update field
                 Self::update_host(field, args, &mut current_host.params)?;
             }
         }
-        // sort hosts
-        config.hosts.sort();
 
         Ok(())
     }
@@ -132,21 +143,13 @@ impl SshConfigParser {
                 params.bind_interface = Some(Self::parse_string(args)?);
             }
             Field::CaSignatureAlgorithms => {
-                let algos = Self::parse_comma_separated_list(args)?;
-                if params.ca_signature_algorithms.is_none() {
-                    params.ca_signature_algorithms = Some(Vec::new());
-                }
-                Self::resolve_algorithms(params.ca_signature_algorithms.as_mut().unwrap(), algos);
+                params.ca_signature_algorithms = Some(Self::parse_comma_separated_list(args)?);
             }
             Field::CertificateFile => {
                 params.certificate_file = Some(Self::parse_path(args)?);
             }
             Field::Ciphers => {
-                let algos = Self::parse_comma_separated_list(args)?;
-                if params.ciphers.is_none() {
-                    params.ciphers = Some(Vec::new());
-                }
-                Self::resolve_algorithms(params.ciphers.as_mut().unwrap(), algos);
+                params.ciphers = Some(Self::parse_comma_separated_list(args)?);
             }
             Field::Compression => {
                 params.compression = Some(Self::parse_boolean(args)?);
@@ -159,11 +162,7 @@ impl SshConfigParser {
             }
             Field::Host => { /* already handled before */ }
             Field::HostKeyAlgorithms => {
-                let algos = Self::parse_comma_separated_list(args)?;
-                if params.host_key_algorithms.is_none() {
-                    params.host_key_algorithms = Some(Vec::new());
-                }
-                Self::resolve_algorithms(params.host_key_algorithms.as_mut().unwrap(), algos);
+                params.host_key_algorithms = Some(Self::parse_comma_separated_list(args)?);
             }
             Field::HostName => {
                 params.host_name = Some(Self::parse_string(args)?);
@@ -175,31 +174,16 @@ impl SshConfigParser {
                 params.ignore_unknown = Some(Self::parse_comma_separated_list(args)?);
             }
             Field::KexAlgorithms => {
-                let algos = Self::parse_comma_separated_list(args)?;
-                if params.kex_algorithms.is_none() {
-                    params.kex_algorithms = Some(Vec::new());
-                }
-                Self::resolve_algorithms(params.kex_algorithms.as_mut().unwrap(), algos);
+                params.kex_algorithms = Some(Self::parse_comma_separated_list(args)?);
             }
             Field::Mac => {
-                let algos = Self::parse_comma_separated_list(args)?;
-                if params.mac.is_none() {
-                    params.mac = Some(Vec::new());
-                }
-                Self::resolve_algorithms(params.mac.as_mut().unwrap(), algos);
+                params.mac = Some(Self::parse_comma_separated_list(args)?);
             }
             Field::Port => {
                 params.port = Some(Self::parse_port(args)?);
             }
             Field::PubkeyAcceptedAlgorithms => {
-                let algos = Self::parse_comma_separated_list(args)?;
-                if params.pubkey_accepted_algorithms.is_none() {
-                    params.pubkey_accepted_algorithms = Some(Vec::new());
-                }
-                Self::resolve_algorithms(
-                    params.pubkey_accepted_algorithms.as_mut().unwrap(),
-                    algos,
-                );
+                params.pubkey_accepted_algorithms = Some(Self::parse_comma_separated_list(args)?);
             }
             Field::PubkeyAuthentication => {
                 params.pubkey_authentication = Some(Self::parse_boolean(args)?);
@@ -294,32 +278,6 @@ impl SshConfigParser {
             | Field::XAuthLocation => { /* Ignore fields */ }
         }
         Ok(())
-    }
-
-    /// Resolve algorithms list.
-    /// if the first argument starts with `+`, then the provided algorithms are PUSHED onto existing list
-    /// if the first argument starts with `-`, then the provided algorithms are REMOVED from existing list
-    /// otherwise the provided list will JUST replace the existing list
-    fn resolve_algorithms(current_list: &mut Vec<String>, mut algos: Vec<String>) {
-        let first = algos.first_mut().unwrap();
-        if first.starts_with('+') {
-            // Concat
-            let new_first = first.replacen('+', "", 1);
-            algos[0] = new_first;
-            for algo in algos.into_iter() {
-                if !current_list.contains(&algo) {
-                    current_list.push(algo);
-                }
-            }
-        } else if first.starts_with('-') {
-            // Remove
-            let new_first = first.replacen('-', "", 1);
-            algos[0] = new_first;
-            // Remove algos from current_list
-            current_list.retain(|x| !algos.contains(x));
-        } else {
-            *current_list = algos;
-        }
     }
 
     /// Tokenize line if possible. Returns field name and args
@@ -465,15 +423,15 @@ mod test {
     use super::*;
 
     #[test]
-    fn should_parse_configuration() {
+    fn should_parse_configuration() -> Result<(), SshParserError> {
         let temp = create_ssh_config();
         let file = File::open(temp.path()).expect("Failed to open tempfile");
         let mut reader = BufReader::new(file);
-        let config = SshConfig::default()
-            .parse(&mut reader, ParseRule::STRICT)
-            .unwrap();
-        // Query
-        let params = config.default_params();
+        let config = SshConfig::default().parse(&mut reader, ParseRule::STRICT)?;
+
+        // Query openssh cmdline overrides (options preceding the first `Host` section,
+        // overriding all following options)
+        let params = config.query("*");
         assert_eq!(
             params.ignore_unknown.as_deref().unwrap(),
             &["Pippo", "Pluto"]
@@ -487,12 +445,18 @@ mod test {
         );
         assert_eq!(params.tcp_keep_alive.unwrap(), true);
         assert_eq!(
-            params.ca_signature_algorithms.as_deref().unwrap(),
-            &["random"]
-        );
-        assert_eq!(
             params.ciphers.as_deref().unwrap(),
             &["a-manella", "blowfish"]
+        );
+        assert_eq!(
+            params.pubkey_accepted_algorithms.as_deref().unwrap(),
+            &["desu", "omar-crypt", "fast-omar-crypt"]
+        );
+
+        // Query explicit all-hosts fallback options (`Host *`)
+        assert_eq!(
+            params.ca_signature_algorithms.as_deref().unwrap(),
+            &["random"]
         );
         assert_eq!(
             params.host_key_algorithms.as_deref().unwrap(),
@@ -503,17 +467,20 @@ mod test {
             &["desu", "gigi",]
         );
         assert_eq!(params.mac.as_deref().unwrap(), &["concorde"]);
-        assert_eq!(
-            params.pubkey_accepted_algorithms.as_deref().unwrap(),
-            &["desu", "omar-crypt", "fast-omar-crypt"]
-        );
         assert!(params.bind_address.is_none());
-        // Query 172.26.104.4
+
+        // Query 172.26.104.4, yielding cmdline overrides,
+        // explicit `Host 192.168.*.* 172.26.*.* !192.168.1.30` options,
+        // and all-hosts fallback options.
         let params = config.query("172.26.104.4");
+
+        // cmdline overrides
         assert_eq!(params.compression.unwrap(), true);
         assert_eq!(params.connection_attempts.unwrap(), 10);
         assert_eq!(params.connect_timeout.unwrap(), Duration::from_secs(60));
         assert_eq!(params.tcp_keep_alive.unwrap(), true);
+
+        // all-hosts fallback options, merged with host-specific options
         assert_eq!(
             params.ca_signature_algorithms.as_deref().unwrap(),
             &["random"]
@@ -521,11 +488,11 @@ mod test {
         assert_eq!(
             params.ciphers.as_deref().unwrap(),
             &[
-                "a-manella",
-                "blowfish",
                 "coi-piedi",
                 "cazdecan",
-                "triestin-stretto"
+                "triestin-stretto",
+                "a-manella",
+                "blowfish",
             ]
         );
         assert_eq!(params.mac.as_deref().unwrap(), &["spyro", "deoxys"]);
@@ -544,12 +511,17 @@ mod test {
             ]
         );
         assert_eq!(params.user.as_deref().unwrap(), "omar");
+
         // Query tostapane
         let params = config.query("tostapane");
-        assert_eq!(params.compression.unwrap(), false);
+        assert_eq!(params.compression.unwrap(), true); // cmdline override over host-specific option
         assert_eq!(params.connection_attempts.unwrap(), 10);
         assert_eq!(params.connect_timeout.unwrap(), Duration::from_secs(60));
         assert_eq!(params.tcp_keep_alive.unwrap(), true);
+        assert_eq!(params.remote_forward.unwrap(), 88);
+        assert_eq!(params.user.as_deref().unwrap(), "ciro-esposito");
+
+        // all-hosts fallback options
         assert_eq!(
             params.ca_signature_algorithms.as_deref().unwrap(),
             &["random"]
@@ -563,14 +535,21 @@ mod test {
             params.pubkey_accepted_algorithms.as_deref().unwrap(),
             &["desu", "omar-crypt", "fast-omar-crypt"]
         );
-        assert_eq!(params.remote_forward.unwrap(), 88);
-        assert_eq!(params.user.as_deref().unwrap(), "ciro-esposito");
+
         // query 192.168.1.30
         let params = config.query("192.168.1.30");
+
+        // host-specific options
+        assert_eq!(params.user.as_deref().unwrap(), "nutellaro");
+        assert_eq!(params.remote_forward.unwrap(), 123);
+
+        // cmdline overrides
         assert_eq!(params.compression.unwrap(), true);
         assert_eq!(params.connection_attempts.unwrap(), 10);
         assert_eq!(params.connect_timeout.unwrap(), Duration::from_secs(60));
         assert_eq!(params.tcp_keep_alive.unwrap(), true);
+
+        // all-hosts fallback options
         assert_eq!(
             params.ca_signature_algorithms.as_deref().unwrap(),
             &["random"]
@@ -584,8 +563,8 @@ mod test {
             params.pubkey_accepted_algorithms.as_deref().unwrap(),
             &["desu", "omar-crypt", "fast-omar-crypt"]
         );
-        assert_eq!(params.user.as_deref().unwrap(), "nutellaro");
-        assert_eq!(params.remote_forward.unwrap(), 123);
+
+        Ok(())
     }
 
     #[test]
@@ -638,9 +617,22 @@ mod test {
             .to_string_lossy()
             .to_string();
 
+        let host_params = config.query("remote-host");
+
+        // From `*-host`
         assert_eq!(
-            config.query("remote_host").identity_file.unwrap()[0].as_path(),
+            host_params.identity_file.unwrap()[0].as_path(),
             Path::new(format!("{home_dir}/.ssh/id_rsa_good").as_str())
+        );
+
+        // From `remote-*`
+        assert_eq!(host_params.host_name.unwrap(), "hostname.com");
+        assert_eq!(host_params.user.unwrap(), "user");
+
+        // From `*`
+        assert_eq!(
+            host_params.connect_timeout.unwrap(),
+            Duration::from_secs(15)
         );
     }
 
@@ -924,83 +916,6 @@ mod test {
     }
 
     #[test]
-    fn should_resolve_algorithms_list_when_preceeded_by_plus() {
-        let mut list = vec![
-            "a".to_string(),
-            "b".to_string(),
-            "c".to_string(),
-            "d".to_string(),
-            "e".to_string(),
-        ];
-        let algos = vec![
-            "+1".to_string(),
-            "a".to_string(),
-            "b".to_string(),
-            "3".to_string(),
-            "d".to_string(),
-        ];
-        SshConfigParser::resolve_algorithms(&mut list, algos);
-        assert_eq!(
-            list,
-            vec![
-                "a".to_string(),
-                "b".to_string(),
-                "c".to_string(),
-                "d".to_string(),
-                "e".to_string(),
-                "1".to_string(),
-                "3".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn should_resolve_algorithms_list_when_preceeded_by_minus() {
-        let mut list = vec![
-            "a".to_string(),
-            "b".to_string(),
-            "c".to_string(),
-            "d".to_string(),
-            "e".to_string(),
-        ];
-        let algos = vec!["-a".to_string(), "b".to_string(), "3".to_string()];
-        SshConfigParser::resolve_algorithms(&mut list, algos);
-        assert_eq!(
-            list,
-            vec!["c".to_string(), "d".to_string(), "e".to_string(),]
-        );
-    }
-
-    #[test]
-    fn should_resolve_algorithm_list_when_replacing() {
-        let mut list = vec![
-            "a".to_string(),
-            "b".to_string(),
-            "c".to_string(),
-            "d".to_string(),
-            "e".to_string(),
-        ];
-        let algos = vec![
-            "1".to_string(),
-            "a".to_string(),
-            "b".to_string(),
-            "3".to_string(),
-            "d".to_string(),
-        ];
-        SshConfigParser::resolve_algorithms(&mut list, algos);
-        assert_eq!(
-            list,
-            vec![
-                "1".to_string(),
-                "a".to_string(),
-                "b".to_string(),
-                "3".to_string(),
-                "d".to_string(),
-            ]
-        );
-    }
-
-    #[test]
     fn should_tokenize_line() {
         assert_eq!(
             SshConfigParser::tokenize("HostName 192.168.*.* 172.26.*.*")
@@ -1245,14 +1160,7 @@ ConnectionAttempts          10
 ConnectTimeout 60
 ServerAliveInterval 40
 TcpKeepAlive    yes
-
-CaSignatureAlgorithms   random
-Ciphers     a-manella,blowfish
-HostKeyAlgorithms   luigi,mario
-KexAlgorithms   desu,gigi
-Macs     concorde
-PubkeyAcceptedAlgorithms    desu,omar-crypt,fast-omar-crypt
-
+Ciphers     +a-manella,blowfish
 
 # Let's start defining some hosts
 
@@ -1280,6 +1188,12 @@ Host    192.168.1.30
     User    nutellaro
     RemoteForward   123
 
+Host *
+    CaSignatureAlgorithms   random
+    HostKeyAlgorithms   luigi,mario
+    KexAlgorithms   desu,gigi
+    Macs     concorde
+    PubkeyAcceptedAlgorithms    desu,omar-crypt,fast-omar-crypt
 "##;
         tmpfile.write_all(config.as_bytes()).unwrap();
         tmpfile
@@ -1289,17 +1203,17 @@ Host    192.168.1.30
         let mut tmpfile: tempfile::NamedTempFile =
             tempfile::NamedTempFile::new().expect("Failed to create tempfile");
         let config = r##"
-Host remote_host
-    HostName hostname.com
-    User user
+Host *-host
     IdentityFile ~/.ssh/id_rsa_good
 
-Host remote_*
-    IdentityFile ~/.ssh/id_mid
+Host remote-*
+    HostName hostname.com
+    User user
+    IdentityFile ~/.ssh/id_rsa_bad
 
 Host *
-    AddKeysToAgent yes
-    IdentityFile ~/.ssh/id_rsa_bad
+    ConnectTimeout 15
+    IdentityFile ~/.ssh/id_rsa_ugly
     "##;
         tmpfile.write_all(config.as_bytes()).unwrap();
         tmpfile


### PR DESCRIPTION
# #11 - Correctly apply configuration precedence in reverse parsing order

Fixes #11

## Description

Previously, the order of precedence applied to
parsed configuration was incorrect.

Configuration was parsed, then sorted in
alphabetical order.

Algorithms (ciphers, key
exchange algorithms, MACs, etc.) were incorrectly
applied during parsing.

The correct precedence order follows
https://linux.die.net/man/5/ssh_config: the
configuration is read from top to bottom,
precedence is applied from bottom (lowest)
to the top (highest precedence).

Options preceding the first `Host` block are
considered implicit command line options, in
line with OpenSSH's own implementation.


## This patch includes the following changes:

- Remove the alphabetic ordering of host sections.

- Merge matching host sections in reverse order.

- More efficiently merge host sections with vastly reduced `clone`s. (`clone` on demand.)

- Resolve algorithms not during the parsing, but during the resolving stage.

- More efficiently resolve algorithms, without source list mutation.

- Adjust existing unit tests to test the corrected precedence algorithm.

## Type of change

**This is a bugfix, but some users may depend on the old, broken algorithm. For these users, this change could be considered breaking.**

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The changes I've made are Windows, MacOS, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
