### PR TITLE
#8 - Expose ignored fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,25 @@ fn auth_with_rsakey(
 
 ```
 
+### Reading unsupported fields
+
+As outlined above, ssh2-config does not support all parameters available in the man page of the SSH configuration file. 
+
+If you require these fields you may still access them through the `unsupported_fields` field on the `HostParams` structure like this:
+
+```rust
+use ssh2_config::{ParseRule, SshConfig};
+use std::fs::File;
+use std::io::BufReader;
+
+let mut reader = BufReader::new(File::open(config_path).expect("Could not open configuration file"));
+let config = SshConfig::default().parse(&mut reader, ParseRule::ALLOW_UNSUPPORTED_FIELDS).expect("Failed to parse configuration");
+
+// Query attributes for a certain host
+let params = config.query("192.168.1.2");
+let forwards = params.unsupported_fields.get("dynamicforward");
+```
+
 ### Examples
 
 You can view a working examples of an implementation of ssh2-config with ssh2 in the examples folder at [client.rs](examples/client.rs).

--- a/src/params.rs
+++ b/src/params.rs
@@ -60,6 +60,8 @@ pub struct HostParams {
     pub user: Option<String>,
     /// fields that the parser wasn't able to parse
     pub ignored_fields: HashMap<String, Vec<String>>,
+    /// fields that the parser was able to parse but ignored
+    pub unsupported_fields: HashMap<String, Vec<String>>,
 }
 
 impl HostParams {
@@ -172,6 +174,14 @@ impl HostParams {
                 if !self.ignored_fields.contains_key(ignored_field) {
                     self.ignored_fields
                         .insert(ignored_field.to_owned(), args.to_owned());
+                }
+            }
+        }
+        if !b.unsupported_fields.is_empty() {
+            for (unsupported_field, args) in &b.unsupported_fields {
+                if !self.unsupported_fields.contains_key(unsupported_field) {
+                    self.unsupported_fields
+                        .insert(unsupported_field.to_owned(), args.to_owned());
                 }
             }
         }

--- a/src/parser/field.rs
+++ b/src/parser/field.rs
@@ -2,6 +2,7 @@
 //!
 //! Ssh config fields
 
+use std::fmt;
 use std::str::FromStr;
 
 /// Configuration field.
@@ -212,6 +213,110 @@ impl FromStr for Field {
             // -- unknwon field
             _ => Err(s.to_string()),
         }
+    }
+}
+
+impl fmt::Display for Field {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Host => "host",
+            Self::BindAddress => "bindaddress",
+            Self::BindInterface => "bindinterface",
+            Self::CaSignatureAlgorithms => "casignaturealgorithms",
+            Self::CertificateFile => "certificatefile",
+            Self::Ciphers => "ciphers",
+            Self::Compression => "compression",
+            Self::ConnectionAttempts => "connectionattempts",
+            Self::ConnectTimeout => "connecttimeout",
+            Self::HostKeyAlgorithms => "hostkeyalgorithms",
+            Self::HostName => "hostname",
+            Self::IdentityFile => "identityfile",
+            Self::IgnoreUnknown => "ignoreunknown",
+            Self::KexAlgorithms => "kexalgorithms",
+            Self::Mac => "macs",
+            Self::Port => "port",
+            Self::PubkeyAcceptedAlgorithms => "pubkeyacceptedalgorithms",
+            Self::PubkeyAuthentication => "pubkeyauthentication",
+            Self::RemoteForward => "remoteforward",
+            Self::ServerAliveInterval => "serveraliveinterval",
+            Self::TcpKeepAlive => "tcpkeepalive",
+            #[cfg(target_os = "macos")]
+            Self::UseKeychain => "usekeychain",
+            Self::User => "user",
+            // Continuation of the rest of the enum variants
+            Self::AddKeysToAgent => "addkeystoagent",
+            Self::AddressFamily => "addressfamily",
+            Self::BatchMode => "batchmode",
+            Self::CanonicalDomains => "canonicaldomains",
+            Self::CanonicalizeFallbackLock => "canonicalizefallbacklock",
+            Self::CanonicalizeHostname => "canonicalizehostname",
+            Self::CanonicalizeMaxDots => "canonicalizemaxdots",
+            Self::CanonicalizePermittedCNAMEs => "canonicalizepermittedcnames",
+            Self::CheckHostIP => "checkhostip",
+            Self::ClearAllForwardings => "clearallforwardings",
+            Self::ControlMaster => "controlmaster",
+            Self::ControlPath => "controlpath",
+            Self::ControlPersist => "controlpersist",
+            Self::DynamicForward => "dynamicforward",
+            Self::EnableSSHKeysign => "enablesshkeysign",
+            Self::EscapeChar => "escapechar",
+            Self::ExitOnForwardFailure => "exitonforwardfailure",
+            Self::FingerprintHash => "fingerprinthash",
+            Self::ForkAfterAuthentication => "forkafterauthentication",
+            Self::ForwardAgent => "forwardagent",
+            Self::ForwardX11 => "forwardx11",
+            Self::ForwardX11Timeout => "forwardx11timeout",
+            Self::ForwardX11Trusted => "forwardx11trusted",
+            Self::GatewayPorts => "gatewayports",
+            Self::GlobalKnownHostsFile => "globalknownhostsfile",
+            Self::GSSAPIAuthentication => "gssapiauthentication",
+            Self::GSSAPIDelegateCredentials => "gssapidelegatecredentials",
+            Self::HashKnownHosts => "hashknownhosts",
+            Self::HostbasedAcceptedAlgorithms => "hostbasedacceptedalgorithms",
+            Self::HostbasedAuthentication => "hostbasedauthentication",
+            Self::HostKeyAlias => "hostkeyalias",
+            Self::HostbasedKeyTypes => "hostbasedkeytypes",
+            Self::IdentitiesOnly => "identitiesonly",
+            Self::IdentityAgent => "identityagent",
+            Self::Include => "include",
+            Self::IPQoS => "ipqos",
+            Self::KbdInteractiveAuthentication => "kbdinteractiveauthentication",
+            Self::KbdInteractiveDevices => "kbdinteractivedevices",
+            Self::KnownHostsCommand => "knownhostscommand",
+            Self::LocalCommand => "localcommand",
+            Self::LocalForward => "localforward",
+            Self::LogLevel => "loglevel",
+            Self::LogVerbose => "logverbose",
+            Self::NoHostAuthenticationForLocalhost => "nohostauthenticationforlocalhost",
+            Self::NumberOfPasswordPrompts => "numberofpasswordprompts",
+            Self::PasswordAuthentication => "passwordauthentication",
+            Self::PermitLocalCommand => "permitlocalcommand",
+            Self::PermitRemoteOpen => "permitremoteopen",
+            Self::PKCS11Provider => "pkcs11provider",
+            Self::PreferredAuthentications => "preferredauthentications",
+            Self::ProxyCommand => "proxycommand",
+            Self::ProxyJump => "proxyjump",
+            Self::ProxyUseFdpass => "proxyusefdpass",
+            Self::PubkeyAcceptedKeyTypes => "pubkeyacceptedkeytypes",
+            Self::RekeyLimit => "rekeylimit",
+            Self::RequestTTY => "requesttty",
+            Self::RevokedHostKeys => "revokedhostkeys",
+            Self::SecruityKeyProvider => "secruitykeyprovider",
+            Self::SendEnv => "sendenv",
+            Self::ServerAliveCountMax => "serveralivecountmax",
+            Self::SessionType => "sessiontype",
+            Self::SetEnv => "setenv",
+            Self::StdinNull => "stdinnull",
+            Self::StreamLocalBindMask => "streamlocalbindmask",
+            Self::StrictHostKeyChecking => "stricthostkeychecking",
+            Self::SyslogFacility => "syslogfacility",
+            Self::UpdateHostKeys => "updatehostkeys",
+            Self::UserKnownHostsFile => "userknownhostsfile",
+            Self::VerifyHostKeyDNS => "verifyhostkeydns",
+            Self::VisualHostKey => "visualhostkey",
+            Self::XAuthLocation => "xauthlocation",
+        };
+        write!(f, "{}", s)
     }
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -118,12 +118,16 @@ impl SshConfigParser {
                 // Update field
                 match Self::update_host(field, args, &mut current_host.params) {
                     Ok(()) => Ok(()),
+                    // If we're allowing unsupported fields to be parsed, add them to the map
                     Err(SshParserError::UnsupportedField(field, args))
                         if rules.intersects(ParseRule::ALLOW_UNSUPPORTED_FIELDS) =>
                     {
                         current_host.params.unsupported_fields.insert(field, args);
                         Ok(())
                     }
+                    // Eat the error here to not break the API with this change
+                    // Also it'd be weird to error on correct ssh_config's just because they're
+                    // not supported by this library
                     Err(SshParserError::UnsupportedField(_, _)) => Ok(()),
                     e => e,
                 }?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -33,6 +33,8 @@ pub enum SshParserError {
     MissingArgument,
     #[error("unknown field: {0}")]
     UnknownField(String, Vec<String>),
+    #[error("unknown field: {0}")]
+    UnsupportedField(String, Vec<String>),
     #[error("IO error: {0}")]
     Io(IoError),
 }
@@ -45,6 +47,7 @@ bitflags! {
         const STRICT = 0b00000000;
         /// Allow unknown field
         const ALLOW_UNKNOWN_FIELDS = 0b00000001;
+        const ALLOW_UNSUPPORTED_FIELDS = 0b00000010;
     }
 }
 
@@ -113,7 +116,17 @@ impl SshConfigParser {
                 current_host = config.hosts.last_mut().unwrap();
             } else {
                 // Update field
-                Self::update_host(field, args, &mut current_host.params)?;
+                match Self::update_host(field, args, &mut current_host.params) {
+                    Ok(()) => Ok(()),
+                    Err(SshParserError::UnsupportedField(field, args))
+                        if rules.intersects(ParseRule::ALLOW_UNSUPPORTED_FIELDS) =>
+                    {
+                        current_host.params.unsupported_fields.insert(field, args);
+                        Ok(())
+                    }
+                    Err(SshParserError::UnsupportedField(_, _)) => Ok(()),
+                    e => e,
+                }?;
             }
         }
 
@@ -275,7 +288,9 @@ impl SshConfigParser {
             | Field::UserKnownHostsFile
             | Field::VerifyHostKeyDNS
             | Field::VisualHostKey
-            | Field::XAuthLocation => { /* Ignore fields */ }
+            | Field::XAuthLocation => {
+                return Err(SshParserError::UnsupportedField(field.to_string(), args))
+            }
         }
         Ok(())
     }
@@ -881,11 +896,38 @@ mod test {
     #[test]
     fn should_not_update_host_if_unknown() -> Result<(), SshParserError> {
         let mut params = HostParams::default();
-        SshConfigParser::update_host(
+        let result = SshConfigParser::update_host(
             Field::AddKeysToAgent,
             vec![String::from("yes")],
             &mut params,
-        )?;
+        );
+
+        match result {
+            Ok(()) | Err(SshParserError::UnsupportedField(_, _)) => Ok(()),
+            e => e,
+        }?;
+
+        assert_eq!(params, HostParams::default());
+        Ok(())
+    }
+
+    #[test]
+    fn should_update_host_if_unsupported() -> Result<(), SshParserError> {
+        let mut params = HostParams::default();
+        let result = SshConfigParser::update_host(
+            Field::AddKeysToAgent,
+            vec![String::from("yes")],
+            &mut params,
+        );
+
+        match result {
+            Err(SshParserError::UnsupportedField(field, _)) => {
+                assert_eq!(field, "addkeystoagent");
+                Ok(())
+            }
+            e => e,
+        }?;
+
         assert_eq!(params, HostParams::default());
         Ok(())
     }


### PR DESCRIPTION
#8 - Expose ignored fields

Fixes #8 as that issue was resolved by exposing invalid fields via the API but not ignored ones. Users may now access "raw" fields that ssh2-config normally ignores.

## Description

- I've updated README.md to reflect the changes
- I've made it so that ignored fields can optionally be added to the `unsupported_fields` field of HostParams
- I've added a new ParseRule to allow parsing unsupported fields

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The changes I've made are Windows, MacOS, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
