### PR TITLE
chore(deps): bump `thiserror` to version 2.x; no migration necessary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ version = "0.2.3"
 [dependencies]
 bitflags = "^2"
 dirs = "^5"
-thiserror = "^1"
+thiserror = "^2"
 wildmatch = "^2.1"
 
 [dev-dependencies]


### PR DESCRIPTION
# #14  - Bump thiserror to v2

Fixes #14

## Description

`thiserror` 2.0 has been released.

Upstream release: https://github.com/dtolnay/thiserror/releases/tag/2.0.0

This changeset bumps the dependency to `"^2"`.

No other changes are necessary.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The changes I've made are Windows, MacOS, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
