### PR TITLE
Combine host declarations when serialising

### DIFF
--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -221,7 +221,7 @@ impl<'a> From<&'a SshConfig> for SshConfigSerializer<'a> {
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
-  
+
     use crate::{DefaultAlgorithms, HostClause};
 
     use super::*;


### PR DESCRIPTION
## Description

Where multiple patterns are assigned to a host, put them all in the same `Host ...` declaration rather than printing the host parameters multiple times.

That is, instead of printing:

```
Host servera
    Hostname %h.example.com
    User milliams

Host serverb
    Hostname %h.example.com
    User milliams
```
it will combine them to:
```
Host servera serverb
    Hostname %h.example.com
    User milliams
```

I believe that this is always equivalent to the best of my knowledge of `ssh_config`.

This PR requires #27 in order to make the test pass. Once that is merged, I can update this PR to reflect those changes.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The changes I've made are Windows, MacOS, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
