### PR TITLE
Add AddKeysToAgent, ForwardAgent, ProxyJump fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Even if many attributes are not exposed, since not supported, there is anyway a 
 - **Compression**: you can use this attribute to set whether compression is enabled with `session.set_compress(value)`
 - **ConnectionAttempts**: you can use this attribute to cycle over connect in order to retry
 - **ConnectTimeout**: you can use this attribute to set the connection timeout for the socket
+- **ForwardAgent**: you can use this attribute to forward your agent to the remote server
 - **HostName**: you can use this attribute to get the real name of the host to connect to
 - **IdentityFile**: you can use this attribute to set the keys to try when connecting to remote host.
 - **KexAlgorithms**: you can use this attribute to configure Key exchange methods with `session.method_pref(MethodType::Kex, algos.to_string().as_str())`

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Even if many attributes are not exposed, since not supported, there is anyway a 
 - **KexAlgorithms**: you can use this attribute to configure Key exchange methods with `session.method_pref(MethodType::Kex, algos.to_string().as_str())`
 - **MACs**: you can use this attribute to configure the MAC algos with `session.method_pref(MethodType::MacCs, algos..to_string().as_str())` and `session.method_pref(MethodType::MacSc, algos..to_string().as_str())`
 - **Port**: you can use this attribute to resolve the port to connect to
+- **ProxyJump**: you can use this attribute to specify hosts to jump via
 - **PubkeyAuthentication**: you can use this attribute to set whether to use the pubkey authentication
 - **RemoteForward**: you can use this method to implement port forwarding with `session.channel_forward_listen()`
 - **ServerAliveInterval**: you can use this method to implement keep alive message interval

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Even if many attributes are not exposed, since not supported, there is anyway a 
 
 ### Exposed attributes
 
+- **AddKeysToAgent**: you can use this attribute add keys to the SSH agent
 - **BindAddress**: you can use this attribute to bind the socket to a certain address
 - **BindInterface**: you can use this attribute to bind the socket to a certain network interface
 - **CASignatureAlgorithms**: you can use this attribute to handle CA certificates

--- a/src/params.rs
+++ b/src/params.rs
@@ -34,6 +34,8 @@ pub struct HostParams {
     pub connection_attempts: Option<usize>,
     /// Specifies the timeout used when connecting to the SSH server
     pub connect_timeout: Option<Duration>,
+    /// Specifies whether the connection to the authentication agent (if any) will be forwarded to the remote machine
+    pub forward_agent: Option<bool>,
     /// Specifies the host key signature algorithms that the client wants to use in order of preference
     pub host_key_algorithms: Algorithms,
     /// Specifies the real host name to log into
@@ -84,6 +86,7 @@ impl HostParams {
             compression: None,
             connection_attempts: None,
             connect_timeout: None,
+            forward_agent: None,
             host_key_algorithms: Algorithms::new(&default_algorithms.host_key_algorithms),
             host_name: None,
             identity_file: None,
@@ -129,6 +132,7 @@ impl HostParams {
         self.compression = self.compression.or(b.compression);
         self.connection_attempts = self.connection_attempts.or(b.connection_attempts);
         self.connect_timeout = self.connect_timeout.or(b.connect_timeout);
+        self.forward_agent = self.forward_agent.or(b.forward_agent);
         self.host_name = self.host_name.clone().or_else(|| b.host_name.clone());
         self.identity_file = self
             .identity_file
@@ -213,6 +217,7 @@ mod tests {
         assert!(params.compression.is_none());
         assert!(params.connection_attempts.is_none());
         assert!(params.connect_timeout.is_none());
+        assert!(params.forward_agent.is_none());
         assert_eq!(
             params.host_key_algorithms.algorithms(),
             DefaultAlgorithms::default().host_key_algorithms

--- a/src/params.rs
+++ b/src/params.rs
@@ -52,6 +52,8 @@ pub struct HostParams {
     pub mac: Algorithms,
     /// Specifies the port number to connect on the remote host.
     pub port: Option<u16>,
+    /// Specifies one or more jump proxies as either [user@]host[:port] or an ssh URI
+    pub proxy_jump: Option<Vec<String>>,
     /// Specifies the signature algorithms that will be used for public key authentication
     pub pubkey_accepted_algorithms: Algorithms,
     /// Specifies whether to try public key authentication using SSH keys
@@ -94,6 +96,7 @@ impl HostParams {
             kex_algorithms: Algorithms::new(&default_algorithms.kex_algorithms),
             mac: Algorithms::new(&default_algorithms.mac),
             port: None,
+            proxy_jump: None,
             pubkey_accepted_algorithms: Algorithms::new(
                 &default_algorithms.pubkey_accepted_algorithms,
             ),
@@ -143,6 +146,7 @@ impl HostParams {
             .clone()
             .or_else(|| b.ignore_unknown.clone());
         self.port = self.port.or(b.port);
+        self.proxy_jump = self.proxy_jump.clone().or_else(|| b.proxy_jump.clone());
         self.pubkey_authentication = self.pubkey_authentication.or(b.pubkey_authentication);
         self.remote_forward = self.remote_forward.or(b.remote_forward);
         self.server_alive_interval = self.server_alive_interval.or(b.server_alive_interval);
@@ -231,6 +235,7 @@ mod tests {
         );
         assert_eq!(params.mac.algorithms(), DefaultAlgorithms::default().mac);
         assert!(params.port.is_none());
+        assert!(params.proxy_jump.is_none());
         assert_eq!(
             params.pubkey_accepted_algorithms.algorithms(),
             DefaultAlgorithms::default().pubkey_accepted_algorithms

--- a/src/params.rs
+++ b/src/params.rs
@@ -16,6 +16,8 @@ use crate::DefaultAlgorithms;
 /// Only arguments supported by libssh2 are implemented
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HostParams {
+    /// Specifies whether keys should be automatically added to a running ssh-agent(1)
+    pub add_keys_to_agent: Option<bool>,
     /// Specifies to use the specified address on the local machine as the source address of the connection
     pub bind_address: Option<String>,
     /// Use the specified address on the local machine as the source address of the connection
@@ -73,6 +75,7 @@ impl HostParams {
     /// Create a new [`HostParams`] object with the [`DefaultAlgorithms`]
     pub fn new(default_algorithms: &DefaultAlgorithms) -> Self {
         Self {
+            add_keys_to_agent: None,
             bind_address: None,
             bind_interface: None,
             ca_signature_algorithms: Algorithms::new(&default_algorithms.ca_signature_algorithms),
@@ -113,6 +116,7 @@ impl HostParams {
 
     /// Given a [`HostParams`] object `b`, it will overwrite all the params from `self` only if they are [`None`]
     pub fn overwrite_if_none(&mut self, b: &Self) {
+        self.add_keys_to_agent = self.add_keys_to_agent.or(b.add_keys_to_agent);
         self.bind_address = self.bind_address.clone().or_else(|| b.bind_address.clone());
         self.bind_interface = self
             .bind_interface
@@ -194,6 +198,7 @@ mod tests {
     #[test]
     fn should_initialize_params() {
         let params = HostParams::new(&DefaultAlgorithms::default());
+        assert!(params.add_keys_to_agent.is_none());
         assert!(params.bind_address.is_none());
         assert!(params.bind_interface.is_none());
         assert_eq!(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -219,6 +219,11 @@ impl SshConfigParser {
                 trace!("connection_attempts: {value}",);
                 params.connection_attempts = Some(value);
             }
+            Field::ForwardAgent => {
+                let value = Self::parse_boolean(args)?;
+                trace!("forward_agent: {value}",);
+                params.forward_agent = Some(value);
+            }
             Field::Host => { /* already handled before */ }
             Field::HostKeyAlgorithms => {
                 let rule = Self::parse_algos(args)?;
@@ -313,7 +318,6 @@ impl SshConfigParser {
             | Field::ExitOnForwardFailure
             | Field::FingerprintHash
             | Field::ForkAfterAuthentication
-            | Field::ForwardAgent
             | Field::ForwardX11
             | Field::ForwardX11Timeout
             | Field::ForwardX11Trusted
@@ -1657,8 +1661,8 @@ Ciphers     +a-manella,blowfish
 
 Host 192.168.*.*    172.26.*.*      !192.168.1.30
     User    omar
-    # Forward agent is actually not supported; I just want to see that it wont' fail parsing
-    ForwardAgent    yes
+    # ForwardX11 is actually not supported; I just want to see that it wont' fail parsing
+    ForwardX11    yes
     BindAddress     10.8.0.10
     BindInterface   tun0
     AddKeysToAgent yes

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -263,6 +263,11 @@ impl SshConfigParser {
                 trace!("port: {value}",);
                 params.port = Some(value);
             }
+            Field::ProxyJump => {
+                let rule = Self::parse_comma_separated_list(args)?;
+                trace!("proxy_jump: {rule:?}",);
+                params.proxy_jump = Some(rule);
+            }
             Field::PubkeyAcceptedAlgorithms => {
                 let rule = Self::parse_algos(args)?;
                 trace!("pubkey_accepted_algorithms: {rule:?}",);
@@ -348,7 +353,6 @@ impl SshConfigParser {
             | Field::PKCS11Provider
             | Field::PreferredAuthentications
             | Field::ProxyCommand
-            | Field::ProxyJump
             | Field::ProxyUseFdpass
             | Field::PubkeyAcceptedKeyTypes
             | Field::RekeyLimit
@@ -690,6 +694,10 @@ mod tests {
         );
         assert_eq!(params_172_26_104_4.mac.algorithms(), &["spyro", "deoxys"]); // use subconfig; defined before * macs
         assert_eq!(
+            params_172_26_104_4.proxy_jump.unwrap(),
+            &["jump.example.com"]
+        ); // use subconfig; defined before * macs
+        assert_eq!(
             params_172_26_104_4
                 .pubkey_accepted_algorithms
                 .algorithms()
@@ -738,6 +746,13 @@ mod tests {
         assert_eq!(
             params_tostapane.mac.algorithms(),
             vec!["spyro".to_string(), "deoxys".to_string(),]
+        );
+        assert_eq!(
+            params_tostapane.proxy_jump.unwrap(),
+            vec![
+                "jump1.example.com".to_string(),
+                "jump2.example.com".to_string(),
+            ]
         );
         assert_eq!(
             params_tostapane.pubkey_accepted_algorithms.algorithms(),
@@ -1671,6 +1686,7 @@ Host 192.168.*.*    172.26.*.*      !192.168.1.30
     Macs     spyro,deoxys
     Port 2222
     PubkeyAcceptedAlgorithms    -omar-crypt
+    ProxyJump jump.example.com
 
 Host tostapane
     User    ciro-esposito
@@ -1679,6 +1695,7 @@ Host tostapane
     Compression no
     Pippo yes
     Pluto 56
+    ProxyJump jump1.example.com,jump2.example.com
     Macs +spyro,deoxys
 
 Host    192.168.1.30

--- a/src/parser/field.rs
+++ b/src/parser/field.rs
@@ -21,6 +21,7 @@ pub enum Field {
     Compression,
     ConnectionAttempts,
     ConnectTimeout,
+    ForwardAgent,
     HostKeyAlgorithms,
     HostName,
     IdentityFile,
@@ -55,7 +56,6 @@ pub enum Field {
     ExitOnForwardFailure,
     FingerprintHash,
     ForkAfterAuthentication,
-    ForwardAgent,
     ForwardX11,
     ForwardX11Timeout,
     ForwardX11Trusted,
@@ -124,6 +124,7 @@ impl FromStr for Field {
             "compression" => Ok(Self::Compression),
             "connectionattempts" => Ok(Self::ConnectionAttempts),
             "connecttimeout" => Ok(Self::ConnectTimeout),
+            "forwardagent" => Ok(Self::ForwardAgent),
             "hostkeyalgorithms" => Ok(Self::HostKeyAlgorithms),
             "hostname" => Ok(Self::HostName),
             "identityfile" => Ok(Self::IdentityFile),
@@ -158,7 +159,6 @@ impl FromStr for Field {
             "exitonforwardfailure" => Ok(Self::ExitOnForwardFailure),
             "fingerprinthash" => Ok(Self::FingerprintHash),
             "forkafterauthentication" => Ok(Self::ForkAfterAuthentication),
-            "forwardagent" => Ok(Self::ForwardAgent),
             "forwardx11" => Ok(Self::ForwardX11),
             "forwardx11timeout" => Ok(Self::ForwardX11Timeout),
             "forwardx11trusted" => Ok(Self::ForwardX11Trusted),
@@ -229,6 +229,7 @@ impl fmt::Display for Field {
             Self::Compression => "compression",
             Self::ConnectionAttempts => "connectionattempts",
             Self::ConnectTimeout => "connecttimeout",
+            Self::ForwardAgent => "forwardagent",
             Self::HostKeyAlgorithms => "hostkeyalgorithms",
             Self::HostName => "hostname",
             Self::IdentityFile => "identityfile",
@@ -263,7 +264,6 @@ impl fmt::Display for Field {
             Self::ExitOnForwardFailure => "exitonforwardfailure",
             Self::FingerprintHash => "fingerprinthash",
             Self::ForkAfterAuthentication => "forkafterauthentication",
-            Self::ForwardAgent => "forwardagent",
             Self::ForwardX11 => "forwardx11",
             Self::ForwardX11Timeout => "forwardx11timeout",
             Self::ForwardX11Trusted => "forwardx11trusted",
@@ -362,6 +362,10 @@ mod tests {
         assert_eq!(
             Field::from_str("ConnectTimeout").ok().unwrap(),
             Field::ConnectTimeout
+        );
+        assert_eq!(
+            Field::from_str("ForwardAgent").ok().unwrap(),
+            Field::ForwardAgent
         );
         assert_eq!(Field::from_str("HostName").ok().unwrap(), Field::HostName);
         assert_eq!(

--- a/src/parser/field.rs
+++ b/src/parser/field.rs
@@ -12,6 +12,7 @@ use std::str::FromStr;
 #[derive(Debug, Eq, PartialEq)]
 pub enum Field {
     Host,
+    AddKeysToAgent,
     BindAddress,
     BindInterface,
     CaSignatureAlgorithms,
@@ -36,7 +37,6 @@ pub enum Field {
     UseKeychain,
     User,
     // -- not implemented
-    AddKeysToAgent,
     AddressFamily,
     BatchMode,
     CanonicalDomains,
@@ -115,6 +115,7 @@ impl FromStr for Field {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "host" => Ok(Self::Host),
+            "addkeystoagent" => Ok(Self::AddKeysToAgent),
             "bindaddress" => Ok(Self::BindAddress),
             "bindinterface" => Ok(Self::BindInterface),
             "casignaturealgorithms" => Ok(Self::CaSignatureAlgorithms),
@@ -139,7 +140,6 @@ impl FromStr for Field {
             "usekeychain" => Ok(Self::UseKeychain),
             "user" => Ok(Self::User),
             // -- not implemented fields
-            "addkeystoagent" => Ok(Self::AddKeysToAgent),
             "addressfamily" => Ok(Self::AddressFamily),
             "batchmode" => Ok(Self::BatchMode),
             "canonicaldomains" => Ok(Self::CanonicalDomains),
@@ -220,6 +220,7 @@ impl fmt::Display for Field {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
             Self::Host => "host",
+            Self::AddKeysToAgent => "addkeystoagent",
             Self::BindAddress => "bindaddress",
             Self::BindInterface => "bindinterface",
             Self::CaSignatureAlgorithms => "casignaturealgorithms",
@@ -244,7 +245,6 @@ impl fmt::Display for Field {
             Self::UseKeychain => "usekeychain",
             Self::User => "user",
             // Continuation of the rest of the enum variants
-            Self::AddKeysToAgent => "addkeystoagent",
             Self::AddressFamily => "addressfamily",
             Self::BatchMode => "batchmode",
             Self::CanonicalDomains => "canonicaldomains",
@@ -330,6 +330,10 @@ mod tests {
     #[test]
     fn should_parse_field_from_string() {
         assert_eq!(Field::from_str("Host").ok().unwrap(), Field::Host);
+        assert_eq!(
+            Field::from_str("AddKeysToAgent").ok().unwrap(),
+            Field::AddKeysToAgent
+        );
         assert_eq!(
             Field::from_str("BindAddress").ok().unwrap(),
             Field::BindAddress

--- a/src/parser/field.rs
+++ b/src/parser/field.rs
@@ -29,6 +29,7 @@ pub enum Field {
     KexAlgorithms,
     Mac,
     Port,
+    ProxyJump,
     PubkeyAcceptedAlgorithms,
     PubkeyAuthentication,
     RemoteForward,
@@ -87,7 +88,6 @@ pub enum Field {
     PKCS11Provider,
     PreferredAuthentications,
     ProxyCommand,
-    ProxyJump,
     ProxyUseFdpass,
     PubkeyAcceptedKeyTypes,
     RekeyLimit,
@@ -132,6 +132,7 @@ impl FromStr for Field {
             "kexalgorithms" => Ok(Self::KexAlgorithms),
             "macs" => Ok(Self::Mac),
             "port" => Ok(Self::Port),
+            "proxyjump" => Ok(Self::ProxyJump),
             "pubkeyacceptedalgorithms" => Ok(Self::PubkeyAcceptedAlgorithms),
             "pubkeyauthentication" => Ok(Self::PubkeyAuthentication),
             "remoteforward" => Ok(Self::RemoteForward),
@@ -190,7 +191,6 @@ impl FromStr for Field {
             "pkcs11provider" => Ok(Self::PKCS11Provider),
             "preferredauthentications" => Ok(Self::PreferredAuthentications),
             "proxycommand" => Ok(Self::ProxyCommand),
-            "proxyjump" => Ok(Self::ProxyJump),
             "proxyusefdpass" => Ok(Self::ProxyUseFdpass),
             "pubkeyacceptedkeytypes" => Ok(Self::PubkeyAcceptedKeyTypes),
             "rekeylimit" => Ok(Self::RekeyLimit),
@@ -237,6 +237,7 @@ impl fmt::Display for Field {
             Self::KexAlgorithms => "kexalgorithms",
             Self::Mac => "macs",
             Self::Port => "port",
+            Self::ProxyJump => "proxyjump",
             Self::PubkeyAcceptedAlgorithms => "pubkeyacceptedalgorithms",
             Self::PubkeyAuthentication => "pubkeyauthentication",
             Self::RemoteForward => "remoteforward",
@@ -295,7 +296,6 @@ impl fmt::Display for Field {
             Self::PKCS11Provider => "pkcs11provider",
             Self::PreferredAuthentications => "preferredauthentications",
             Self::ProxyCommand => "proxycommand",
-            Self::ProxyJump => "proxyjump",
             Self::ProxyUseFdpass => "proxyusefdpass",
             Self::PubkeyAcceptedKeyTypes => "pubkeyacceptedkeytypes",
             Self::RekeyLimit => "rekeylimit",
@@ -377,6 +377,7 @@ mod tests {
             Field::IgnoreUnknown
         );
         assert_eq!(Field::from_str("Macs").ok().unwrap(), Field::Mac);
+        assert_eq!(Field::from_str("ProxyJump").ok().unwrap(), Field::ProxyJump);
         assert_eq!(
             Field::from_str("PubkeyAcceptedAlgorithms").ok().unwrap(),
             Field::PubkeyAcceptedAlgorithms


### PR DESCRIPTION
## Description

Add in support for the `AddKeysToAgent`, `ForwardAgent`, and `ProxyJump` fields.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The changes I've made are Windows, MacOS, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
