### PR TITLE
fix(build): KEX Algorithms were invalidly extracted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+    - [0.6.5](#065)
     - [0.6.4](#064)
     - [0.6.3](#063)
     - [0.6.2](#062)
@@ -24,6 +25,13 @@
     - [0.1.0](#010)
 
 ---
+
+## 0.6.5
+
+Released on 14/01/2026
+
+- [Issue 37](https://github.com/veeso/ssh2-config/issues/37): KEX Algorithms were invalidly extracted
+    - Also removed duplicated and invalid algorithms from the default list.
 
 ## 0.6.4
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 name = "ssh2-config"
 readme = "README.md"
 repository = "https://github.com/veeso/ssh2-config"
-version = "0.6.4"
+version = "0.6.5"
 build = "build/main.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ the list.
 To reload algos, build ssh2-config with `RELOAD_SSH_ALGO` env variable set.
 
 When you invoke `SshConfig::default`, the default algorithms are set from OpenSSH source code, which can be found
-here: <https://docs.rs/ssh2-config/latest/ssh2-config/fn.default_openssh_algorithms.html>.
+here: <https://docs.rs/ssh2_config/latest/ssh2_config/fn.default_openssh_algorithms.html>.
 
 If you want you can use a custom constructor `SshConfig::default().default_algorithms(prefs)` to set your own default
 algorithms.

--- a/build/src_writer.rs
+++ b/build/src_writer.rs
@@ -72,24 +72,10 @@ pub fn write_source(prefs: MyPrefs) -> anyhow::Result<()> {
 fn write_vec(file: &mut std::fs::File, name: &str, vec: &[String]) -> anyhow::Result<()> {
     writeln!(file, r#"        {name}: vec!["#)?;
     for item in vec {
-        writeln!(file, r#"            {item}.to_string(),"#,)?;
+        writeln!(file, r#"            "{item}".to_string(),"#,)?;
     }
     writeln!(file, r#"        ],"#)?;
     Ok(())
-}
-
-struct SrcPaths {
-    src_dir: PathBuf,
-    src_path: PathBuf,
-}
-
-fn src_path() -> SrcPaths {
-    let src_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("src")
-        .join("default_algorithms");
-    let src_path = src_dir.join("openssh.rs");
-
-    SrcPaths { src_dir, src_path }
 }
 
 /// Writes algorithms in documentation format
@@ -106,4 +92,18 @@ fn write_algos_in_docs(
     writeln!(file, "///")?;
 
     Ok(())
+}
+
+struct SrcPaths {
+    src_dir: PathBuf,
+    src_path: PathBuf,
+}
+
+fn src_path() -> SrcPaths {
+    let src_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("default_algorithms");
+    let src_path = src_dir.join("openssh.rs");
+
+    SrcPaths { src_dir, src_path }
 }

--- a/src/default_algorithms/openssh.rs
+++ b/src/default_algorithms/openssh.rs
@@ -27,58 +27,6 @@ use crate::DefaultAlgorithms;
 /// - `diffie-hellman-group16-sha512`
 /// - `diffie-hellman-group18-sha512`
 /// - `diffie-hellman-group14-sha256`
-/// - `ssh-ed25519-cert-v01@openssh.com`
-/// - `ecdsa-sha2-nistp256-cert-v01@openssh.com`
-/// - `ecdsa-sha2-nistp384-cert-v01@openssh.com`
-/// - `ecdsa-sha2-nistp521-cert-v01@openssh.com`
-/// - `sk-ssh-ed25519-cert-v01@openssh.com`
-/// - `sk-ecdsa-sha2-nistp256-cert-v01@openssh.com`
-/// - `rsa-sha2-512-cert-v01@openssh.com`
-/// - `rsa-sha2-256-cert-v01@openssh.com`
-/// - `ssh-ed25519`
-/// - `ecdsa-sha2-nistp256`
-/// - `ecdsa-sha2-nistp384`
-/// - `ecdsa-sha2-nistp521`
-/// - `sk-ssh-ed25519@openssh.com`
-/// - `sk-ecdsa-sha2-nistp256@openssh.com`
-/// - `rsa-sha2-512`
-/// - `rsa-sha2-256`
-/// - `chacha20-poly1305@openssh.com`
-/// - `aes128-gcm@openssh.com`
-/// - `aes256-gcm@openssh.com`
-/// - `aes128-ctr`
-/// - `aes192-ctr`
-/// - `aes256-ctr`
-/// - `chacha20-poly1305@openssh.com`
-/// - `aes128-gcm@openssh.com`
-/// - `aes256-gcm@openssh.com`
-/// - `aes128-ctr`
-/// - `aes192-ctr`
-/// - `aes256-ctr`
-/// - `umac-64-etm@openssh.com`
-/// - `umac-128-etm@openssh.com`
-/// - `hmac-sha2-256-etm@openssh.com`
-/// - `hmac-sha2-512-etm@openssh.com`
-/// - `hmac-sha1-etm@openssh.com`
-/// - `umac-64@openssh.com`
-/// - `umac-128@openssh.com`
-/// - `hmac-sha2-256`
-/// - `hmac-sha2-512`
-/// - `hmac-sha1`
-/// - `umac-64-etm@openssh.com`
-/// - `umac-128-etm@openssh.com`
-/// - `hmac-sha2-256-etm@openssh.com`
-/// - `hmac-sha2-512-etm@openssh.com`
-/// - `hmac-sha1-etm@openssh.com`
-/// - `umac-64@openssh.com`
-/// - `umac-128@openssh.com`
-/// - `hmac-sha2-256`
-/// - `hmac-sha2-512`
-/// - `hmac-sha1`
-/// - `none`
-/// - `zlib@openssh.com`
-/// - `none`
-/// - `zlib@openssh.com`
 ///
 /// ## Host Key algorithms
 ///
@@ -193,58 +141,6 @@ pub fn defaults() -> DefaultAlgorithms {
             "diffie-hellman-group16-sha512".to_string(),
             "diffie-hellman-group18-sha512".to_string(),
             "diffie-hellman-group14-sha256".to_string(),
-            "ssh-ed25519-cert-v01@openssh.com".to_string(),
-            "ecdsa-sha2-nistp256-cert-v01@openssh.com".to_string(),
-            "ecdsa-sha2-nistp384-cert-v01@openssh.com".to_string(),
-            "ecdsa-sha2-nistp521-cert-v01@openssh.com".to_string(),
-            "sk-ssh-ed25519-cert-v01@openssh.com".to_string(),
-            "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com".to_string(),
-            "rsa-sha2-512-cert-v01@openssh.com".to_string(),
-            "rsa-sha2-256-cert-v01@openssh.com".to_string(),
-            "ssh-ed25519".to_string(),
-            "ecdsa-sha2-nistp256".to_string(),
-            "ecdsa-sha2-nistp384".to_string(),
-            "ecdsa-sha2-nistp521".to_string(),
-            "sk-ssh-ed25519@openssh.com".to_string(),
-            "sk-ecdsa-sha2-nistp256@openssh.com".to_string(),
-            "rsa-sha2-512".to_string(),
-            "rsa-sha2-256".to_string(),
-            "chacha20-poly1305@openssh.com".to_string(),
-            "aes128-gcm@openssh.com".to_string(),
-            "aes256-gcm@openssh.com".to_string(),
-            "aes128-ctr".to_string(),
-            "aes192-ctr".to_string(),
-            "aes256-ctr".to_string(),
-            "chacha20-poly1305@openssh.com".to_string(),
-            "aes128-gcm@openssh.com".to_string(),
-            "aes256-gcm@openssh.com".to_string(),
-            "aes128-ctr".to_string(),
-            "aes192-ctr".to_string(),
-            "aes256-ctr".to_string(),
-            "umac-64-etm@openssh.com".to_string(),
-            "umac-128-etm@openssh.com".to_string(),
-            "hmac-sha2-256-etm@openssh.com".to_string(),
-            "hmac-sha2-512-etm@openssh.com".to_string(),
-            "hmac-sha1-etm@openssh.com".to_string(),
-            "umac-64@openssh.com".to_string(),
-            "umac-128@openssh.com".to_string(),
-            "hmac-sha2-256".to_string(),
-            "hmac-sha2-512".to_string(),
-            "hmac-sha1".to_string(),
-            "umac-64-etm@openssh.com".to_string(),
-            "umac-128-etm@openssh.com".to_string(),
-            "hmac-sha2-256-etm@openssh.com".to_string(),
-            "hmac-sha2-512-etm@openssh.com".to_string(),
-            "hmac-sha1-etm@openssh.com".to_string(),
-            "umac-64@openssh.com".to_string(),
-            "umac-128@openssh.com".to_string(),
-            "hmac-sha2-256".to_string(),
-            "hmac-sha2-512".to_string(),
-            "hmac-sha1".to_string(),
-            "none".to_string(),
-            "zlib@openssh.com".to_string(),
-            "none".to_string(),
-            "zlib@openssh.com".to_string(),
         ],
         mac: vec![
             "umac-64-etm@openssh.com".to_string(),


### PR DESCRIPTION
# KEX Algorithms incorrectly extracted from `openssh-portable`

Also removed duplicated and invalid algorithms from the default list

closes #37

