### PR TITLE
fix(parser): accumulate IdentityFile directives across Host blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+    - [0.6.6](#066)
     - [0.6.5](#065)
     - [0.6.4](#064)
     - [0.6.3](#063)
@@ -25,6 +26,12 @@
     - [0.1.0](#010)
 
 ---
+
+## 0.6.6
+
+Released on 31/01/2026
+
+- Multiple `IdentityFile` directives are now accumulated instead of following first-value-wins rule, matching OpenSSH behavior.
 
 ## 0.6.5
 


### PR DESCRIPTION
## Summary

- Multiple `IdentityFile` directives are now accumulated instead of following the first-value-wins rule, matching OpenSSH behavior
- Updated parser to append values when multiple `IdentityFile` directives are encountered within the same Host block
- Updated `overwrite_if_none` to accumulate identity files across Host blocks during `query()`

Closes #39

## Test plan

- [x] Unit tests for parser accumulation within same Host block
- [x] Unit tests for `overwrite_if_none` accumulation across Host blocks
- [x] Integration test validating full flow with `Host test` and `Host *` blocks
- [x] All 145 tests pass
- [x] Clippy passes with no warnings

🤖 Generated with [Claude Code](https://claude.ai/code)