### PR TITLE
fix(parser): handle escape sequences in quoted arguments (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Released on 31/01/2026
   quoted strings instead of treating them as comments.
 - [Issue 45](https://github.com/veeso/ssh2-config/issues/45): Parser now returns an error for mismatched quotes instead
   of silently ignoring them.
+- [Issue 44](https://github.com/veeso/ssh2-config/issues/44): Parser now handles escape sequences (`\"`, `\\`, `\'`)
+  within quoted arguments.
 
 ## 0.6.5
 


### PR DESCRIPTION
## Summary

- Fixes #44: Parser now handles escape sequences within quoted arguments
- Added support for `\"` (escaped double quote), `\\` (escaped backslash), and `\'` (escaped single quote)
- Unrecognized escape sequences preserve the backslash, matching OpenSSH's `argv_split()` behavior

## Test plan

- [x] Added `should_unescape_quoted_args` test for integration testing
- [x] Added `should_count_unescaped_quotes` unit test
- [x] Added `should_detect_ends_with_unescaped_quote` unit test  
- [x] Added `should_unescape_string` unit test
- [x] All 151 tests pass
- [x] Clippy passes with no warnings
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.ai/code)