### PR TITLE
fix(parser): handle multiple '!' characters in host patterns correctly (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Released on 31/01/2026
   of silently ignoring them.
 - [Issue 44](https://github.com/veeso/ssh2-config/issues/44): Parser now handles escape sequences (`\"`, `\\`, `\'`)
   within quoted arguments.
+- [Issue 46](https://github.com/veeso/ssh2-config/issues/46): Fixed pattern parsing to handle multiple `!` characters
+  correctly. Only a leading `!` indicates negation; subsequent `!` characters are treated as literal.
 
 ## 0.6.5
 


### PR DESCRIPTION
## Summary

- Fixed pattern parsing to correctly handle multiple `!` characters in host patterns
- Only the leading `!` character is now treated as a negation marker
- Any subsequent `!` characters are treated as literal characters in the pattern

Fixes #46

## Changes

- Replaced `split('!')` with `strip_prefix('!')` in `parse_host()` function
- Added comprehensive test cases for edge cases (`host!name`, `!host!name`, `!a!b!c`, `a!b`)

## Test plan

- [x] New test `should_parse_host_with_exclamation_in_pattern` covers all edge cases
- [x] All 152 tests pass
- [x] Clippy clean
- [x] Formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)