### PR TITLE
fix(parser): preserve quoted spans with whitespace across multiple args (#52)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# These are supported funding model platforms
+
+github: veeso
+liberapay: veeso
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [0.7.1](#071)
+    - [Fixed](#fixed)
   - [0.7.0](#070)
   - [0.6.5](#065)
   - [0.6.4](#064)
@@ -26,6 +28,19 @@
   - [0.1.0](#010)
 
 ---
+
+## 0.7.1
+
+Released on 2026-04-26
+
+### Fixed
+
+- **parser:** preserve quoted spans with whitespace across multiple args (#52)
+  > Previously, tokenize_line only handled a single fully-quoted argument; multi-argument
+  > lines split on whitespace and broke quoted values containing spaces (e.g. SetEnv
+  > TEST="Test 2"). Introduce split_args_respecting_quotes to walk chars with quote-state,
+  > keeping quoted spans intact and preserving backslash escapes verbatim. Single fully-
+  > quoted args continue to be stripped and unescaped for backward compatibility.
 
 ## 0.7.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 name = "ssh2-config"
 readme = "README.md"
 repository = "https://github.com/veeso/ssh2-config"
-version = "0.7.0"
+version = "0.7.1"
 build = "build/main.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # ssh2-config
 
-[![license-mit](https://img.shields.io/crates/l/ssh2-config.svg)](https://opensource.org/licenses/MIT)
+[![license-mit](https://img.shields.io/crates/l/ssh2-config.svg?logo=rust)](https://opensource.org/licenses/MIT)
 [![repo-stars](https://img.shields.io/github/stars/veeso/ssh2-config?style=flat)](https://github.com/veeso/ssh2-config/stargazers)
-[![downloads](https://img.shields.io/crates/d/ssh2-config.svg)](https://crates.io/crates/ssh2-config)
-[![latest-version](https://img.shields.io/crates/v/ssh2-config.svg)](https://crates.io/crates/ssh2-config)
-[![ko-fi](https://img.shields.io/badge/donate-ko--fi-red)](https://ko-fi.com/veeso)
+[![downloads](https://img.shields.io/crates/d/ssh2-config.svg?logo=rust)](https://crates.io/crates/ssh2-config)
+[![latest-version](https://img.shields.io/crates/v/ssh2-config.svg?logo=rust)](https://crates.io/crates/ssh2-config)
 [![conventional-commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 
 [![Build](https://github.com/veeso/ssh2-config/actions/workflows/build.yml/badge.svg)](https://github.com/veeso/ssh2-config/actions/workflows/build.yml)
@@ -14,19 +13,19 @@
 ---
 
 - [ssh2-config](#ssh2-config)
-    - [About ssh2-config](#about-ssh2-config)
-        - [Exposed attributes](#exposed-attributes)
-        - [Missing features](#missing-features)
-    - [Get started 🚀](#get-started)
-        - [Reading unsupported fields](#reading-unsupported-fields)
-    - [How host parameters are resolved](#how-host-parameters-are-resolved)
-        - [Resolvers examples](#resolvers-examples)
-    - [Configuring default algorithms](#configuring-default-algorithms)
-        - [Examples](#examples)
-    - [Support the developer ☕](#support-the-developer-)
-    - [Contributing and issues 🤝🏻](#contributing-and-issues-)
-    - [Changelog ⏳](#changelog-)
-    - [License 📃](#license-)
+  - [About ssh2-config](#about-ssh2-config)
+    - [Exposed attributes](#exposed-attributes)
+    - [Missing features](#missing-features)
+  - [Get started](#get-started)
+    - [Reading unsupported fields](#reading-unsupported-fields)
+  - [How host parameters are resolved](#how-host-parameters-are-resolved)
+    - [Resolvers examples](#resolvers-examples)
+  - [Configuring default algorithms](#configuring-default-algorithms)
+    - [Examples](#examples)
+  - [Support the developer ☕](#support-the-developer-)
+  - [Contributing and issues 🤝🏻](#contributing-and-issues-)
+  - [Changelog ⏳](#changelog-)
+  - [License 📃](#license-)
 
 ---
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,47 @@
+[changelog]
+body = """
+## {{ version | trim_start_matches(pat="v") }}
+
+Released on {{ timestamp | date(format="%Y-%m-%d") }}
+{%- if commits | filter(attribute="breaking", value=true) | length > 0 %}
+
+### ⚠ Breaking Changes
+
+{%- for commit in commits | filter(attribute="breaking", value=true) %}
+- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat="\n") | first | trim }}
+  {%- if commit.breaking_description %}
+  > {{ commit.breaking_description }}
+  {%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- for group, commits in commits | group_by(attribute="group") %}
+
+### {{ group | upper_first }}
+
+{% for commit in commits -%}
+- {% if commit.breaking %}💥 {% endif %}{% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat="\n") | first | trim }}
+  {%- if commit.body %}
+  > {{ commit.body | split(pat="\n") | join(sep="\n  > ") }}
+  {%- endif %}
+{%- endfor %}
+{%- endfor %}
+"""
+trim = false
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+  { message = "^feat", group = "Added" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^refactor", group = "Changed" },
+  { message = "^perf", group = "Performance" },
+  { message = "^doc", group = "Documentation" },
+  { message = "^test", group = "Testing" },
+  { message = "^ci", group = "CI" },
+  { message = "^chore", group = "Miscellaneous" },
+]
+filter_commits = false
+tag_pattern = "v[0-9].*"
+sort_commits = "oldest"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -198,6 +198,47 @@ impl SshConfigParser {
         result
     }
 
+    /// Split an argument string by whitespace while keeping quoted spans (`"..."`) as part of
+    /// the same token. Backslash escapes inside quotes (`\"`, `\\`) are preserved verbatim so
+    /// the caller can decide whether to unescape. Tokens may mix quoted and unquoted parts
+    /// (e.g. `KEY="value with spaces"`).
+    fn split_args_respecting_quotes(s: &str) -> Vec<String> {
+        let mut result = Vec::new();
+        let mut current = String::new();
+        let mut has_token = false;
+        let mut in_quotes = false;
+        let mut chars = s.chars().peekable();
+        while let Some(c) = chars.next() {
+            if in_quotes {
+                current.push(c);
+                if c == '\\' {
+                    if let Some(&nc) = chars.peek() {
+                        current.push(nc);
+                        chars.next();
+                    }
+                } else if c == '"' {
+                    in_quotes = false;
+                }
+            } else if c.is_whitespace() {
+                if has_token {
+                    result.push(std::mem::take(&mut current));
+                    has_token = false;
+                }
+            } else if c == '"' {
+                current.push(c);
+                in_quotes = true;
+                has_token = true;
+            } else {
+                current.push(c);
+                has_token = true;
+            }
+        }
+        if has_token {
+            result.push(current);
+        }
+        result
+    }
+
     /// Count unescaped double quotes in a string.
     /// A quote is considered escaped if preceded by a backslash that is not itself escaped.
     fn count_unescaped_quotes(s: &str) -> usize {
@@ -604,21 +645,22 @@ impl SshConfigParser {
             return Err(SshParserError::InvalidQuotes);
         }
 
-        // if args is quoted, don't split it
-        let args = if other_tokens.starts_with('"') && Self::ends_with_unescaped_quote(other_tokens)
+        // split arguments while respecting quoted spans (whitespace inside quotes is preserved)
+        let raw_tokens = Self::split_args_respecting_quotes(other_tokens);
+
+        // if entire args is a single fully-quoted token, strip quotes and unescape
+        let args = if raw_tokens.len() == 1
+            && raw_tokens[0].starts_with('"')
+            && raw_tokens[0].len() >= 2
+            && Self::ends_with_unescaped_quote(&raw_tokens[0])
         {
-            trace!("quoted args: '{other_tokens}'",);
-            let content = &other_tokens[1..other_tokens.len() - 1];
+            trace!("quoted args: '{}'", raw_tokens[0]);
+            let t = &raw_tokens[0];
+            let content = &t[1..t.len() - 1];
             vec![Self::unescape_string(content)]
         } else {
-            trace!("splitting args (non-quoted): '{other_tokens}'",);
-            // split by whitespace
-            let tokens = other_tokens.split_whitespace();
-
-            tokens
-                .map(|x| x.trim().to_string())
-                .filter(|x| !x.is_empty())
-                .collect()
+            trace!("split args: {:?}", raw_tokens);
+            raw_tokens
         };
 
         match Field::from_str(field) {
@@ -2078,6 +2120,26 @@ Host test
         let (field, args) = SshConfigParser::tokenize_line(r#"HostName "test\nvalue""#).unwrap();
         assert_eq!(field, Field::HostName);
         assert_eq!(args, vec![r#"test\nvalue"#.to_string()]);
+    }
+
+    #[test]
+    fn should_tokenize_line_setenv() -> Result<(), SshParserError> {
+        crate::test_log();
+        assert_eq!(
+            SshConfigParser::tokenize_line(
+                r#"SetEnv TEST_1=Test1 TEST_2="Test 2" TEST_3="Test \"3\"" TEST_4=Test"4""#
+            )?,
+            (
+                Field::SetEnv,
+                vec![
+                    r#"TEST_1=Test1"#.to_owned(),
+                    r#"TEST_2="Test 2""#.to_owned(),
+                    r#"TEST_3="Test \"3\"""#.to_owned(),
+                    r#"TEST_4=Test"4""#.to_owned(),
+                ]
+            )
+        );
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Tokenizer split multi-arg lines on whitespace before honoring quotes, breaking values like `SetEnv TEST="Test 2"`.
- New `split_args_respecting_quotes` walks chars with quote-state, keeping quoted spans intact and preserving `\"`/`\\` escapes verbatim.
- Single fully-quoted argument path retained for backward compatibility (still strips + unescapes).

Closes #52

## Test plan
- [x] New TDD test `should_tokenize_line_setenv` covers the issue's reproducer.
- [x] `cargo test` — 153 passed, 0 failed.
- [x] Existing quoted-args tests still pass.