### PR TITLE
feat(build): gate build deps behind reload-ssh-algo feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ cargo run --example print -- [config-path]
 cargo run --example client -- <host> [config-path]
 
 # Regenerate default algorithms from OpenSSH source
-RELOAD_SSH_ALGO=1 cargo build
+cargo build --features reload-ssh-algo
 ```
 
 **Test environment setup:** Tests require `~/.ssh/config` to exist (can be empty).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,12 +40,13 @@ ssh2 = "^0.9"
 tempfile = "^3"
 
 [build-dependencies]
-anyhow = "1"
-git2 = "0.20"
+anyhow = { version = "1", optional = true }
+git2 = { version = "0.20", optional = true }
 
 [features]
 default = []
 nolog = ["log/max_level_off"]
+reload-ssh-algo = ["dep:anyhow", "dep:git2"]
 
 [[example]]
 name = "client"

--- a/build/main.rs
+++ b/build/main.rs
@@ -1,15 +1,17 @@
+#[cfg(feature = "reload-ssh-algo")]
 mod define_parser;
+#[cfg(feature = "reload-ssh-algo")]
 mod openssh;
+#[cfg(feature = "reload-ssh-algo")]
 mod src_writer;
 
+#[cfg(feature = "reload-ssh-algo")]
 fn main() -> anyhow::Result<()> {
-    // If reload SSH ALGO is not set, we don't need to do anything
-    if std::env::var("RELOAD_SSH_ALGO").is_err() {
-        return Ok(());
-    }
-
     let prefs = openssh::get_my_prefs()?;
     src_writer::write_source(prefs)?;
 
     Ok(())
 }
+
+#[cfg(not(feature = "reload-ssh-algo"))]
+fn main() {}


### PR DESCRIPTION
## Summary

- Replace `RELOAD_SSH_ALGO` env var with optional cargo feature `reload-ssh-algo`.
- `anyhow` and `git2` are now optional build-dependencies, gated by the feature.
- Default `cargo build` no longer compiles those deps (or their openssl C bindings).

Trigger algorithm regeneration via `cargo build --features reload-ssh-algo` instead of `RELOAD_SSH_ALGO=1 cargo build`.

Closes #51

## Test plan

- [x] `cargo build` (default) — no anyhow/git2 compiled
- [x] `cargo check --features reload-ssh-algo` — builds clean
- [x] `cargo clippy -- -Dwarnings` — passes